### PR TITLE
the game.engine is now a string enum

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -36,7 +36,7 @@ describe('parseReplay', () => {
         expect(parsedReplayOrigLocalGame1.header).toHaveProperty('metadata.checksum')
         expect(parsedReplayOrigLocalGame1.header?.data.game).toMatchInlineSnapshot(`
 {
-  "engine": 0,
+  "engine": "starcraft",
   "frame": 13936,
   "name": "supergentle",
   "startedAtInSec": 1743740565,
@@ -71,7 +71,7 @@ describe('parseReplay', () => {
         expect(parsedReplayBwLadderGame1.header).toHaveProperty('metadata.checksum')
         expect(parsedReplayBwLadderGame1.header?.data.game).toMatchInlineSnapshot(`
 {
-  "engine": 1,
+  "engine": "broodwar",
   "frame": 10754,
   "name": "AH\`gPwk]]WZC",
   "startedAtInSec": 1742809475,
@@ -107,7 +107,7 @@ describe('parseReplay', () => {
         expect(parsedReplayBwLadderGame2.header).toHaveProperty('metadata.checksum')
         expect(parsedReplayBwLadderGame2.header?.data.game).toMatchInlineSnapshot(`
 {
-  "engine": 1,
+  "engine": "broodwar",
   "frame": 6971,
   "name": "fNxbHwocBGaS",
   "startedAtInSec": 1742470968,
@@ -143,7 +143,7 @@ describe('parseReplay', () => {
         expect(parsedReplayBwLadderGame3.header).toHaveProperty('metadata.checksum')
         expect(parsedReplayBwLadderGame3.header?.data.game).toMatchInlineSnapshot(`
 {
-  "engine": 1,
+  "engine": "broodwar",
   "frame": 11055,
   "name": "YrPRFmVSXUwp",
   "startedAtInSec": 1704885363,

--- a/src/parsers/sections/header/sectionNode.ts
+++ b/src/parsers/sections/header/sectionNode.ts
@@ -1,8 +1,19 @@
 import {createLinkedListNode} from "../../../dataTypes/LinkedList";
 import {parseSection} from "../../parseSection";
-import {SectionNodeData} from "../types";
+import {GameEngine, SectionNodeData} from "../types";
 import {isPrintableByte} from "../../../utils";
-import {parseHeaderPlayers, HEADER_PLAYERS_BUFFER_SIZE} from "./parseHeaderPlayers";
+import {parseHeaderPlayers} from "./parseHeaderPlayers";
+
+const mapByteToGameEnum = (byte: number) => {
+    switch (byte) {
+        case 0x0:
+            return GameEngine.Starcraft
+        case 0x1:
+            return GameEngine.Broodwar
+        default:
+            return GameEngine.Unknown
+    }
+}
 
 export const headerSectionNode = createLinkedListNode<SectionNodeData>('header', {
     parser: (buffer, offset, result) => {
@@ -10,7 +21,7 @@ export const headerSectionNode = createLinkedListNode<SectionNodeData>('header',
         const {metadata, dataBuffer, getNextSectionOffset} = parseSection(sectionBuffer)
 
         const game = {
-            engine: dataBuffer.readUint8(0x0),
+            engine: mapByteToGameEnum(dataBuffer.readUint8(0x0)),
             frame: dataBuffer.readUint32LE(0x1),
             startedAtInSec: dataBuffer.readUint32LE(0x8),
             name: dataBuffer.subarray(0x18, 0x18 + 28).filter(isPrintableByte).toString()

--- a/src/parsers/sections/types.ts
+++ b/src/parsers/sections/types.ts
@@ -9,6 +9,12 @@ export type ParsedSection<T> = {
     data: T
 }
 
+export enum GameEngine {
+    Starcraft = 'starcraft',
+    Broodwar = 'broodwar',
+    Unknown = 'unknown'
+}
+
 export enum PlayerType {
     Human = 'human',
     Computer = 'computer',
@@ -37,7 +43,7 @@ export type ParsedHeaderPlayers = {
 
 export type ParsedHeaderSectionData = {
     game: {
-        engine: number
+        engine: GameEngine
         frame: number
         startedAtInSec: number
         name: string


### PR DESCRIPTION
## Changes
The game engine field in the header section was number, but now its an enum value: 'starcraft' or 'broodwar'